### PR TITLE
Add output hooks for setup scripts

### DIFF
--- a/script/full-stop
+++ b/script/full-stop
@@ -159,11 +159,14 @@ install_brew_packages () {
 }
 
 run_topic_installers () {
+  local script_path="$( cd "$(dirname "$0")" ; pwd -P )"
+  local output_hooks="$script_path/output-hooks.sh"
+
   # find the installers and run them iteratively
   for installer in $(find -H "$DOTFILES_DIR" -depth 2 -name 'setup.sh' -not -path '*.git*')
   do
-    info "sh -c $installer"
-    sh -c $installer
+    info "sh -c $installer $output_hooks"
+    sh -c "$installer $output_hooks"
   done
 }
 

--- a/script/output-hooks.sh
+++ b/script/output-hooks.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+header () {
+  printf "\r  [ \033[00;34mINSTALL\033[0m ] %-10s$1\n" "======="
+}
+
+info () {
+  printf "\r\t  [ \033[00;34m..\033[0m ] $1\n"
+}
+
+user () {
+  printf "\r\t  [ \033[0;33m??\033[0m ] $1\n"
+}
+
+success () {
+  printf "\r\t\033[2K  [ \033[00;32mOK\033[0m ] $1\n"
+}
+
+fail () {
+  printf "\r\t\033[2K  [\033[0;31mFAIL\033[0m] $1\n"
+  echo ''
+  exit
+}


### PR DESCRIPTION
This way, setup.sh scripts can hook into the full-stop output to provide
a better experience.