### PR TITLE
Do not force full-stop to be inside DOTFILES_DIR

### DIFF
--- a/script/full-stop
+++ b/script/full-stop
@@ -27,16 +27,9 @@ fail () {
 }
 
 check_dotfiles_dir () {
-  local current_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
   if ! [ -d "$DOTFILES_DIR" ]
   then
     fail "expected to find a $DOTFILES_DIR directory"
-  fi
-
-  if [ "$FULL_STOP_DIR/script" != "$current_dir" ]
-  then
-    fail "your dotfiles must go in $DOTFILES_DIR, and Full Stop in $FULL_STOP_DIR"
   fi
 }
 


### PR DESCRIPTION
Does not fail when full stop is located outside of `$DOTFILES_DIR`